### PR TITLE
Add registry mirror env for preKubeadmCommands

### DIFF
--- a/.sharing.io/init
+++ b/.sharing.io/init
@@ -15,6 +15,10 @@ if [ -f /var/run/secrets/kubernetes.io/serviceaccount/namespace ]; then
     kubectl get ns $APP_NAMESPACE || kubectl create ns $APP_NAMESPACE
     kubectl get ns $APP_NAMESPACE-instances || kubectl create ns $APP_NAMESPACE-instances
 
+    kubectl label ns "${APP_NAMESPACE}" cert-manager-tls=sync
+
+    envsubst < $GIT_ROOT/.sharing.io/pair-dev-registry.yaml | kubectl apply -f -
+
     envsubst < $GIT_ROOT/.sharing.io/pair-soa.yaml | kubectl apply -f -
 
     if [ ! -f $GIT_ROOT/.env ]; then
@@ -41,6 +45,7 @@ APP_PORT=127.0.0.1:8080
 APP_TARGET_NAMESPACE=${APP_NAMESPACE}-instances
 APP_BASE_HOST=pair.${SHARINGIO_PAIR_BASE_DNS_NAME}
 APP_NON_ADMIN_INSTANCE_MAX_AMOUNT=1000
+APP_INSTANCE_CONTAINER_REGISTRY_MIRRORS=https://docker-mirror.${SHARINGIO_PAIR_BASE_DNS_NAME}
 EOF
     fi
 

--- a/.sharing.io/pair-dev-registry.yaml
+++ b/.sharing.io/pair-dev-registry.yaml
@@ -1,0 +1,140 @@
+# Source: sharingio-pair/templates/configmap-registry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sharingio-pair-registry
+  namespace: sharingio-pair
+  labels:
+    app: registry
+    app.kubernetes.io/part-of: sharingio-pair
+data:
+  config.yml: |
+    health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3
+    http:
+      addr: :5000
+      headers:
+        X-Content-Type-Options:
+        - nosniff
+    log:
+      fields:
+        service: registry
+    proxy:
+      remoteurl: https://registry-1.docker.io
+    storage:
+      cache:
+        blobdescriptor: inmemory
+      filesystem:
+        rootdirectory: /var/lib/registry
+    version: 0.1
+---
+# Source: sharingio-pair/templates/service-registry.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: sharingio-pair-registry
+  namespace: sharingio-pair
+  labels:
+    app: registry
+    app.kubernetes.io/part-of: sharingio-pair
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: 5000
+      protocol: TCP
+      name: http
+  selector:
+    app: registry
+    app.kubernetes.io/part-of: sharingio-pair
+---
+# Source: sharingio-pair/templates/deployment-registry.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sharingio-pair-registry
+  namespace: sharingio-pair
+  labels:
+    app: registry
+    app.kubernetes.io/part-of: sharingio-pair
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+      app.kubernetes.io/part-of: sharingio-pair
+  template:
+    metadata:
+      labels:
+        app: registry
+        app.kubernetes.io/part-of: sharingio-pair
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: sharingio-pair-registry
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          image: "registry:2.7.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: TZ
+              value: Pacific/Auckland
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 1
+            periodSeconds: 20
+          volumeMounts:
+            - name: distribution-config
+              mountPath: /etc/docker/registry/config.yml
+              subPath: config.yml
+            - name: var-lib-registry
+              mountPath: /var/lib/registry
+          resources: {}
+      volumes:
+        - name: distribution-config
+          configMap:
+            name: sharingio-pair-registry
+        - name: var-lib-registry
+          emptyDir: {}
+---
+# Source: sharingio-pair/templates/ingress-registry.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sharingio-pair-registry
+  namespace: sharingio-pair
+spec:
+  tls:
+    - hosts:
+        - "docker-mirror.${SHARINGIO_PAIR_BASE_DNS_NAME}"
+      secretName: letsencrypt-prod
+  rules:
+    - host: "docker-mirror.${SHARINGIO_PAIR_BASE_DNS_NAME}"
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: sharingio-pair-registry
+                port:
+                  number: 5000
+---

--- a/apps/cluster-api-manager/common/common.go
+++ b/apps/cluster-api-manager/common/common.go
@@ -91,10 +91,10 @@ func GetNonAdminInstanceMaxAmount() int {
 	return max
 }
 
-// GetInstanceContainerRegistryMirror ...
+// GetInstanceContainerRegistryMirrors ...
 // returns the url to a mirror container registry
-func GetInstanceContainerRegistryMirror() string {
-	return GetEnvOrDefault("APP_INSTANCE_CONTAINER_REGISTRY_MIRROR", "")
+func GetInstanceContainerRegistryMirrors() []string {
+	return strings.Split(GetEnvOrDefault("APP_INSTANCE_CONTAINER_REGISTRY_MIRRORS", ""), " ")
 }
 
 // Logging ...

--- a/apps/cluster-api-manager/common/common.go
+++ b/apps/cluster-api-manager/common/common.go
@@ -91,6 +91,12 @@ func GetNonAdminInstanceMaxAmount() int {
 	return max
 }
 
+// GetInstanceContainerRegistryMirror ...
+// returns the url to a mirror container registry
+func GetInstanceContainerRegistryMirror() string {
+	return GetEnvOrDefault("APP_INSTANCE_CONTAINER_REGISTRY_MIRROR", "")
+}
+
 // Logging ...
 // basic request logging middleware
 func Logging(next http.Handler) http.Handler {

--- a/apps/cluster-api-manager/instances/kubernetes.go
+++ b/apps/cluster-api-manager/instances/kubernetes.go
@@ -608,7 +608,7 @@ func KubernetesDelete(name string, kubernetesClientset dynamic.Interface) (err e
 // given an instance spec and namespace, return KubernetesCluster resources
 func KubernetesTemplateResources(instance InstanceSpec, namespace string) (err error, newInstance KubernetesCluster) {
 	instance.NodeSize = common.ReturnValueOrDefault(instance.NodeSize, GetInstanceDefaultNodeSize())
-	instance.RegistryMirror = common.GetInstanceContainerRegistryMirror()
+	instance.RegistryMirrors = common.GetInstanceContainerRegistryMirrors()
 	instance.Setup.EnvironmentVersion = common.ReturnValueOrDefault(instance.Setup.EnvironmentVersion, GetEnvironmentVersion())
 	instance.Setup.EnvironmentRepository = common.ReturnValueOrDefault(instance.Setup.EnvironmentRepository, GetEnvironmentRepository())
 	instance.Setup.KubernetesVersion = common.ReturnValueOrDefault(instance.Setup.KubernetesVersion, GetKubernetesVersion())
@@ -633,8 +633,8 @@ func KubernetesTemplateResources(instance InstanceSpec, namespace string) (err e
 cat << EOF >> /root/.sharing-io-pair-init.env
 export KUBERNETES_VERSION={{ $.Setup.KubernetesVersion }}
 export SHARINGIO_PAIR_INSTANCE_SETUP_USER="{{ $.Setup.User }}"
-{{ if $.RegistryMirror }}
-export SHARINGIO_PAIR_INSTANCE_CONTAINER_REGISTRY_MIRROR="{{ $.RegistryMirror }}"
+{{ if $.RegistryMirrors }}
+export SHARINGIO_PAIR_INSTANCE_CONTAINER_REGISTRY_MIRRORS="{{ range $.RegistryMirrors }}{{ . }} {{ end }}"
 {{ end }}
 EOF
 . /root/.sharing-io-pair-init.env

--- a/apps/cluster-api-manager/instances/kubernetes.go
+++ b/apps/cluster-api-manager/instances/kubernetes.go
@@ -608,6 +608,7 @@ func KubernetesDelete(name string, kubernetesClientset dynamic.Interface) (err e
 // given an instance spec and namespace, return KubernetesCluster resources
 func KubernetesTemplateResources(instance InstanceSpec, namespace string) (err error, newInstance KubernetesCluster) {
 	instance.NodeSize = common.ReturnValueOrDefault(instance.NodeSize, GetInstanceDefaultNodeSize())
+	instance.RegistryMirror = common.GetInstanceContainerRegistryMirror()
 	instance.Setup.EnvironmentVersion = common.ReturnValueOrDefault(instance.Setup.EnvironmentVersion, GetEnvironmentVersion())
 	instance.Setup.EnvironmentRepository = common.ReturnValueOrDefault(instance.Setup.EnvironmentRepository, GetEnvironmentRepository())
 	instance.Setup.KubernetesVersion = common.ReturnValueOrDefault(instance.Setup.KubernetesVersion, GetKubernetesVersion())
@@ -632,6 +633,9 @@ func KubernetesTemplateResources(instance InstanceSpec, namespace string) (err e
 cat << EOF >> /root/.sharing-io-pair-init.env
 export KUBERNETES_VERSION={{ $.Setup.KubernetesVersion }}
 export SHARINGIO_PAIR_INSTANCE_SETUP_USER="{{ $.Setup.User }}"
+{{ if $.RegistryMirror }}
+export SHARINGIO_PAIR_INSTANCE_CONTAINER_REGISTRY_MIRROR="{{ $.RegistryMirror }}"
+{{ end }}
 EOF
 . /root/.sharing-io-pair-init.env
 `)

--- a/apps/cluster-api-manager/instances/types.go
+++ b/apps/cluster-api-manager/instances/types.go
@@ -28,7 +28,7 @@ type InstanceSpec struct {
 	KubernetesNodeCount int                `json:"kubernetesNodeCount"`
 	Facility            string             `json:"facility"`
 	NameScheme          InstanceNameScheme `json:"nameScheme"`
-	RegistryMirror      string             `json:"registryMirror"`
+	RegistryMirrors     []string           `json:"registryMirrors"`
 }
 
 // InstanceResourceStatus ...

--- a/apps/cluster-api-manager/instances/types.go
+++ b/apps/cluster-api-manager/instances/types.go
@@ -28,6 +28,7 @@ type InstanceSpec struct {
 	KubernetesNodeCount int                `json:"kubernetesNodeCount"`
 	Facility            string             `json:"facility"`
 	NameScheme          InstanceNameScheme `json:"nameScheme"`
+	RegistryMirror      string             `json:"registryMirror"`
 }
 
 // InstanceResourceStatus ...

--- a/charts/sharingio-pair/templates/cert.yaml
+++ b/charts/sharingio-pair/templates/cert.yaml
@@ -17,5 +17,12 @@ spec:
     {{- range .Values.ingress.hosts }}
     - {{ .host | quote }}
     {{- end }}
+    {{- if .Values.registry.enabled }}
+    {{- if .Values.registry.ingress.certmanager.enabled }}
+    {{- range .Values.registry.ingress.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sharingio-pair/templates/cluster-issuer.yaml
+++ b/charts/sharingio-pair/templates/cluster-issuer.yaml
@@ -22,5 +22,12 @@ spec:
             {{- range .Values.ingress.hosts }}
             - {{ .host | quote }}
             {{- end }}
+            {{- if .Values.registry.enabled }}
+            {{- if .Values.registry.ingress.certmanager.enabled }}
+            {{- range .Values.registry.ingress.hosts }}
+            - {{ .host | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sharingio-pair/templates/configmap-registry.yaml
+++ b/charts/sharingio-pair/templates/configmap-registry.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.registry.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sharingio-pair.fullname" . }}-registry
+  labels:
+    app: registry
+    app.kubernetes.io/part-of: sharingio-pair
+    {{- include "sharingio-pair.labels" . | nindent 4 }}
+data:
+  config.yml: |
+    {{- toYaml .Values.registry.config | nindent 4 }}
+{{- end }}

--- a/charts/sharingio-pair/templates/deployment-cluster-api-manager.yaml
+++ b/charts/sharingio-pair/templates/deployment-cluster-api-manager.yaml
@@ -76,6 +76,8 @@ spec:
               value: "{{ .Values.adminEmailDomain }}"
             - name: APP_NON_ADMIN_INSTANCE_MAX_AMOUNT
               value: "{{ .Values.maxInstancesForNonAdmins }}"
+            - name: APP_INSTANCE_CONTAINER_REGISTRY_MIRRORS
+              value: "{{ range .Values.registry.ingress.hosts }}https://{{ .host }} {{ end }}{{ range .Values.instance.extraRegistryMirrors }}https://{{ . }} {{ end }}"
             {{- end }}
             {{- if .Values.clusterapimanager.extraEnv }}
             {{- toYaml .Values.clusterapimanager.extraEnv | nindent 12 }}

--- a/charts/sharingio-pair/templates/deployment-registry.yaml
+++ b/charts/sharingio-pair/templates/deployment-registry.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: sharingio-pair
     {{- include "sharingio-pair.labels" . | nindent 4 }}
   annotations:
-    checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    checksum/configmap-registry: {{ include (print $.Template.BasePath "/configmap-registry.yaml") . | sha256sum }}
 spec:
 {{- if not .Values.registry.autoscaling.enabled }}
   replicas: {{ .Values.registry.replicaCount }}
@@ -53,15 +53,20 @@ spec:
               protocol: TCP
           readinessProbe:
             tcpSocket:
-              port: 5000
+              port: {{ .Values.registry.service.port }}
             initialDelaySeconds: 2
             periodSeconds: 10
           livenessProbe:
             tcpSocket:
-              port: 5000
+              port: {{ .Values.registry.service.port }}
             initialDelaySeconds: 1
             periodSeconds: 20
-
+          volumeMounts:
+          - name: distribution-config
+            mountPath: /etc/docker/registry/config.yml
+            subPath: config.yml
+          - name: var-lib-registry
+            mountPath: /var/lib/registry
           resources:
             {{- toYaml .Values.registry.resources | nindent 12 }}
       {{- with .Values.registry.nodeSelector }}
@@ -79,7 +84,7 @@ spec:
       volumes:
         - name: distribution-config
           configMap:
-            name: distribution-config
-        - name: distribution-auth
-          secret:
-            secretName: distribution-auth
+            name: {{ include "sharingio-pair.fullname" . }}-registry
+        - name: var-lib-registry
+          emptyDir: {}
+{{- end }}

--- a/charts/sharingio-pair/templates/deployment-registry.yaml
+++ b/charts/sharingio-pair/templates/deployment-registry.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.registry.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sharingio-pair.fullname" . }}-registry
+  labels:
+    app: registry
+    app.kubernetes.io/part-of: sharingio-pair
+    {{- include "sharingio-pair.labels" . | nindent 4 }}
+  annotations:
+    checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+spec:
+{{- if not .Values.registry.autoscaling.enabled }}
+  replicas: {{ .Values.registry.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: registry
+      app.kubernetes.io/part-of: sharingio-pair
+      {{- include "sharingio-pair.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.registry.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        app: registry
+        app.kubernetes.io/part-of: sharingio-pair
+        {{- include "sharingio-pair.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.registry.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-registry
+          securityContext:
+            {{- toYaml .Values.registry.securityContext | nindent 12 }}
+          image: "{{ .Values.registry.image.repository }}:{{ .Values.registry.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.registry.image.pullPolicy }}
+          env:
+            - name: TZ
+              value: {{ .Values.timezone }}
+            {{- if .Values.registry.extraEnv }}
+            {{- toYaml .Values.registry.extraEnv | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.registry.service.port }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 1
+            periodSeconds: 20
+
+          resources:
+            {{- toYaml .Values.registry.resources | nindent 12 }}
+      {{- with .Values.registry.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.registry.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.registry.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: distribution-config
+          configMap:
+            name: distribution-config
+        - name: distribution-auth
+          secret:
+            secretName: distribution-auth

--- a/charts/sharingio-pair/templates/ingress-registry.yaml
+++ b/charts/sharingio-pair/templates/ingress-registry.yaml
@@ -1,30 +1,30 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.registry.enabled -}}
 {{- $fullName := include "sharingio-pair.fullname" . -}}
-{{- $svcPort := .Values.client.service.port -}}
+{{- $svcPort := .Values.registry.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-registry
   labels:
     {{- include "sharingio-pair.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.registry.ingress.annotations }}
   annotations:
-    {{- if $.Values.ingress.certmanager.enabled }}
+    {{- if $.Values.registry.ingress.certmanager.enabled }}
     cert-manager.io/cluster-issuer: {{ include "sharingio-pair.fullname" . }}-letsencrypt
     {{- end }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.certmanager }}
+  {{- if .Values.registry.ingress.certmanager }}
   tls:
     - hosts:
-    {{- range .Values.ingress.hosts }}
+    {{- range .Values.registry.ingress.hosts }}
         - {{ .host | quote }}
     {{- end }}
       secretName: {{ include "sharingio-pair.fullname" . }}-letsencrypt
-  {{- else if .Values.ingress.tls }}
+  {{- else if .Values.registry.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range .Values.registry.ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -33,7 +33,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range .Values.registry.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -42,7 +42,7 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ $fullName }}-client
+                name: {{ $fullName }}-registry
                 port:
                   number: {{ $svcPort }}
           {{- end }}

--- a/charts/sharingio-pair/templates/service-registry.yaml
+++ b/charts/sharingio-pair/templates/service-registry.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.registry.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sharingio-pair.fullname" . }}-registry
+  labels:
+    app: registry
+    app.kubernetes.io/part-of: sharingio-pair
+    {{- include "sharingio-pair.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.registry.service.type }}
+  ports:
+    - port: {{ .Values.registry.service.port }}
+      targetPort: {{ .Values.registry.service.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: registry
+    app.kubernetes.io/part-of: sharingio-pair
+    {{- include "sharingio-pair.selectorLabels" . | nindent 4 }}
+{{- end}}

--- a/charts/sharingio-pair/values.yaml
+++ b/charts/sharingio-pair/values.yaml
@@ -32,6 +32,7 @@ instance:
   environmentVersion: ""
   environmentRepository: registry.gitlab.com/sharingio/environment
   nodeSize: ""
+  extraRegistryMirrors: []
 
 # secrets for pulling images
 imagePullSecrets: []
@@ -250,6 +251,8 @@ reconciler:
   tolerations: []
 
 registry:
+  enabled: false
+
   config:
     version: 0.1
     log:
@@ -284,8 +287,8 @@ registry:
 
   podAnnotations: {}
 
-  podSecurityContext: {}
-  # fsGroup: 2000
+  podSecurityContext:
+    fsGroup: 1000
 
   securityContext:
     readOnlyRootFilesystem: true
@@ -305,7 +308,22 @@ registry:
 
   service:
     type: ClusterIP
-    port: 8080
+    port: 5000
+
+  ingress:
+    enabled: false
+    certmanager:
+      enabled: false
+    annotations: {}
+    #   kubernetes.io/ingress.class: nginx
+    #   kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: registry.chart-example.local
+        paths: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/sharingio-pair/values.yaml
+++ b/charts/sharingio-pair/values.yaml
@@ -248,3 +248,95 @@ reconciler:
   nodeSelector: {}
 
   tolerations: []
+
+registry:
+  config:
+    version: 0.1
+    log:
+      fields:
+        service: registry
+    storage:
+      cache:
+        blobdescriptor: inmemory
+      filesystem:
+        rootdirectory: /var/lib/registry
+    http:
+      addr: :5000
+      headers:
+        X-Content-Type-Options: [nosniff]
+    health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3
+    proxy:
+      remoteurl: https://registry-1.docker.io
+
+  replicaCount: 1
+
+  image:
+    repository: registry
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: 2.7.1
+
+  nameOverride: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+  # fsGroup: 2000
+
+  securityContext:
+    readOnlyRootFilesystem: true
+    privileged: false
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+  extraEnv: []
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+  affinity: {}
+
+  nodeSelector: {}
+
+  tolerations: []

--- a/manifests/pair.yaml
+++ b/manifests/pair.yaml
@@ -85,3 +85,13 @@ spec:
         - host: ${SHARINGIO_PAIR_HOST}
           paths:
             - /
+    registry:
+      enabled: true
+      ingress:
+        enabled: true
+        certmanager:
+          enabled: true
+        hosts:
+          - host: docker-mirror.sharing.io
+            paths:
+              - /

--- a/org/debugging/debugging.org
+++ b/org/debugging/debugging.org
@@ -16,6 +16,12 @@ kubectl -n sharingio-pair logs -l app=client -f --tail=100
 kubectl -n cluster-api-provider-packet-system logs -l control-plane=packet-controller-manager,cluster.x-k8s.io/provider=infrastructure-packet -f --tail=100 -c manager
 #+end_src
 
+* Helm chart
+Render the Helm chart with values from [[../../manifests/pair.yaml][pair.yaml]]
+#+begin_src tmate :window pair-debug
+helm template sharingio-pair -n sharingio-pair -f <(< ./manifests/pair.yaml SHARINGIO_PAIR_HOST=pair.sharing.io envsubst | yq e .spec.values -P -) charts/sharingio-pair/
+#+end_src
+
 * Instance
 ** Finding labels
 #+begin_src shell :wrap "SRC yaml"


### PR DESCRIPTION
This PR seeks to address the issues with instances that try to pull from Docker Hub. There is limiting on amount of pull per IP (per image ?) and as a results, some instances don't come up.

When the environment variable _APP_INSTANCE_CONTAINER_REGISTRY_MIRROR_ is passed to _cluster-api-manager_, the environment variable _SHARINGIO_PAIR_INSTANCE_CONTAINER_REGISTRY_MIRRORS_ will be set in the preKubeadmCommands script for configuring registry mirrors in Docker on instances