### PR TITLE
Add wildcard permitted org access

### DIFF
--- a/apps/client/src/client/github.clj
+++ b/apps/client/src/client/github.clj
@@ -48,7 +48,7 @@
   [orgs]
   (let [permitted-orgs (set (clojure.string/split (env :pair-permitted-orgs) #" "))
         user-orgs (set (map :login orgs))]
-    ((complement empty?) (clojure.set/intersection user-orgs permitted-orgs))))
+    (or ((complement empty?) (clojure.set/intersection user-orgs permitted-orgs)) (= (env :pair-permitted-orgs) "*"))))
 
 (s/fdef is-admin?
   :args (s/cat :emails :gh/emails)

--- a/manifests/pair.yaml
+++ b/manifests/pair.yaml
@@ -10,10 +10,7 @@ spec:
     path: charts/sharingio-pair
   values:
     permittedOrgs:
-      - sharingio
-      - cncf
-      - kubernetes
-      - ii
+      - "*"
     adminEmailDomain: ii.coop
     instance:
       kubernetesVersion: 1.23.5

--- a/manifests/pair.yaml
+++ b/manifests/pair.yaml
@@ -16,7 +16,7 @@ spec:
       kubernetesVersion: 1.23.5
       environmentRepository: registry.gitlab.com/sharingio/environment/environment
       environmentVersion: 2022.03.30.1618
-      nodeSize: m1.xlarge.x86
+      nodeSize: c2.medium.x86
     sessionSecret: pairpairpairpair
     maxInstancesForNonAdmins: 1
     githubOAuth:


### PR DESCRIPTION
Adds support for setting the permitted-org value to `*` for any access.

(unrelated but in this PR for ease is, updating the default node size)