### PR TITLE
Fix Helm templating for permitted orgs

### DIFF
--- a/charts/sharingio-pair/templates/deployment-client.yaml
+++ b/charts/sharingio-pair/templates/deployment-client.yaml
@@ -69,7 +69,7 @@ spec:
             - name: TZ
               value: {{ .Values.timezone }}
             - name: PAIR_PERMITTED_ORGS
-              value: "{{ range .Values.permittedOrgs }}{{ . }} {{ end }}"
+              value: "{{ range $i, $v := .Values.permittedOrgs }}{{$i}}:{{ $v }}{{ if not (eq (len $.Values.permittedOrgs) (add $i 1)) }} {{ end }}{{ end }}"
             - name: PAIR_ADMIN_EMAIL_DOMAIN
               value: "{{ .Values.adminEmailDomain }}"
             - name: MAX_INSTANCE_LIMIT


### PR DESCRIPTION
Removes the trailing space from the value of the `$PAIR_PERMITTED_ORGS` variable on the client deployment