### PR TITLE
Add variables for NodeOS

### DIFF
--- a/apps/cluster-api-manager/instances/common.go
+++ b/apps/cluster-api-manager/instances/common.go
@@ -13,6 +13,7 @@ import (
 // misc default vars
 var (
 	instanceDefaultNodeSize              = "c3.small.x86"
+	instanceDefaultNodeOS                = "ubuntu_20_04"
 	instanceDefaultTimezone              = "Pacific/Auckland"
 	instanceDefaultEnvironmentRepository = "registry.gitlab.com/sharingio/environment/environment"
 	instanceDefaultEnvironmentVersion    = "2022.03.30.1618"
@@ -35,6 +36,12 @@ func GetEnvironmentVersion() string {
 // get the version of Kubernetes to use in the cluster
 func GetKubernetesVersion() string {
 	return common.GetEnvOrDefault("APP_INSTANCE_KUBERNETES_VERSION", instanceDefaultKubernetesVersion)
+}
+
+// GetInstanceDefaultNodeOS ...
+// get the OS of node to create
+func GetInstanceDefaultNodeOS() string {
+	return common.GetEnvOrDefault("APP_INSTANCE_NODE_OS", instanceDefaultNodeOS)
 }
 
 // GetInstanceDefaultNodeSize ...

--- a/apps/cluster-api-manager/instances/kubernetes.go
+++ b/apps/cluster-api-manager/instances/kubernetes.go
@@ -75,11 +75,6 @@ func Int32ToInt32Pointer(input int32) *int32 {
 	return &input
 }
 
-// misc vars
-var (
-	defaultMachineOS = "ubuntu_20_04"
-)
-
 // KubernetesGet ...
 // Get a Kubernetes instance
 func KubernetesGet(name string, kubernetesClientset dynamic.Interface, clientset *kubernetes.Clientset) (instance Instance, err error) {
@@ -616,6 +611,7 @@ func KubernetesDelete(name string, kubernetesClientset dynamic.Interface) (err e
 // given an instance spec and namespace, return KubernetesCluster resources
 func KubernetesTemplateResources(instance InstanceSpec, namespace string) (newInstance KubernetesCluster, err error) {
 	instance.NodeSize = common.ReturnValueOrDefault(instance.NodeSize, GetInstanceDefaultNodeSize())
+	instance.NodeOS = common.ReturnValueOrDefault(instance.NodeOS, GetInstanceDefaultNodeOS())
 	instance.RegistryMirrors = common.GetInstanceContainerRegistryMirrors()
 	instance.Setup.EnvironmentVersion = common.ReturnValueOrDefault(instance.Setup.EnvironmentVersion, GetEnvironmentVersion())
 	instance.Setup.EnvironmentRepository = common.ReturnValueOrDefault(instance.Setup.EnvironmentRepository, GetEnvironmentRepository())
@@ -928,7 +924,7 @@ EOF`,
 			Spec: clusterAPIPacketv1alpha3.PacketMachineTemplateSpec{
 				Template: clusterAPIPacketv1alpha3.PacketMachineTemplateResource{
 					Spec: clusterAPIPacketv1alpha3.PacketMachineSpec{
-						OS:           defaultMachineOS,
+						OS:           instance.NodeOS,
 						BillingCycle: "hourly",
 						// 1 = machine type
 						MachineType: "",
@@ -957,7 +953,7 @@ EOF`,
 			Spec: clusterAPIPacketv1alpha3.PacketMachineTemplateSpec{
 				Template: clusterAPIPacketv1alpha3.PacketMachineTemplateResource{
 					Spec: clusterAPIPacketv1alpha3.PacketMachineSpec{
-						OS:           defaultMachineOS,
+						OS:           instance.NodeOS,
 						BillingCycle: "hourly",
 						// 1 = machine type
 						MachineType: "",
@@ -1632,6 +1628,7 @@ func KubernetesGetInstanceEnvironmentPodReadiness(clientset *kubernetes.Clientse
 // this way is a quick way to test new fields for new instances, but ideally these fields will be written by the client
 func UpdateInstanceSpecIfEnvOverrides(instance InstanceSpec) InstanceSpec {
 	instance.NodeSize = common.ReturnValueOrDefault(GetValueFromEnvSlice(instance.Setup.Env, "__SHARINGIO_PAIR_NODE_SIZE"), instance.NodeSize)
+	instance.NodeOS = common.ReturnValueOrDefault(GetValueFromEnvSlice(instance.Setup.Env, "__SHARINGIO_PAIR_NODE_OS"), instance.NodeOS)
 	instance.Setup.EnvironmentVersion = common.ReturnValueOrDefault(GetValueFromEnvSlice(instance.Setup.Env, "__SHARINGIO_PAIR_ENVIRONMENT_VERSION"), instance.Setup.EnvironmentVersion)
 	instance.Setup.EnvironmentRepository = common.ReturnValueOrDefault(GetValueFromEnvSlice(instance.Setup.Env, "__SHARINGIO_PAIR_ENVIRONMENT_REPOSITORY"), instance.Setup.EnvironmentRepository)
 	instance.Setup.KubernetesVersion = common.ReturnValueOrDefault(GetValueFromEnvSlice(instance.Setup.Env, "__SHARINGIO_PAIR_KUBERNETES_VERSION"), instance.Setup.KubernetesVersion)

--- a/apps/cluster-api-manager/instances/types.go
+++ b/apps/cluster-api-manager/instances/types.go
@@ -25,6 +25,7 @@ type InstanceSpec struct {
 	Type                InstanceType       `json:"type"`
 	Setup               types.SetupSpec    `json:"setup"`
 	NodeSize            string             `json:"nodeSize"`
+	NodeOS              string             `json:"nodeOS"`
 	KubernetesNodeCount int                `json:"kubernetesNodeCount"`
 	Facility            string             `json:"facility"`
 	NameScheme          InstanceNameScheme `json:"nameScheme"`


### PR DESCRIPTION
Allows the base OS to be configurable to what is supported by Equinix Metal via the env var `__SHARINGIO_PAIR_NODE_OS`