### PR TITLE
Update handling of SSH keys for GitHub accounts

### DIFF
--- a/apps/client/src/client/github.clj
+++ b/apps/client/src/client/github.clj
@@ -46,9 +46,10 @@
   :ret (s/nilable string?))
 (defn user-ssh-keys
   [username]
-  (try
-    (:body (http/get (str "https://github.com/" username ".keys")))
-    (catch Exception e nil)))
+  (let [req (try+ (-> (http/get (str "https://github.com/" username ".keys")))
+                      (catch Object e
+                        (log/warn (str "Couldn't get SSH keys from GitHub user '" username "'; error: " e)) nil))]
+    (:body req)))
 
 (s/fdef in-permitted-org?
   :args (s/cat :orgs :gh/orgs)


### PR DESCRIPTION
Currently some users of Pair are experiencing a 502 when trying to log in.
This behaviour has begun since these changes
https://github.com/sharingio/pair/compare/fdc243649284060cbd881adbd9867f2327f2394f...b6653aa374b9e28435b03a2db742e693e60df7a7
Since the auth is in the github.clj and that was the only file that was modified to do with it, this issue must be to do with this file. In investigating this issue, the function for getting SSH keys is different to all the other ones, where it using a try-catch mechanism. I suspect that the behaviour is slightly different to the other functions.

Co-Authored-By: robertkielty <robertkielty@users.noreply.github.com>