### PR TITLE
Tidy up site info

### DIFF
--- a/apps/client/resources/public/stylesheets/main.css
+++ b/apps/client/resources/public/stylesheets/main.css
@@ -134,9 +134,14 @@ nav#login-options {
   align-items: center;
 }
 
-#cta p.tagline {
+#cta p.home-title {
   font-size: 2rem;
   font-weight: 700;
+  text-align: center;
+  margin-bottom: var(--section-spacing);
+}
+
+#cta p.tagline {
   text-align: center;
   margin-bottom: var(--section-spacing);
 }

--- a/apps/client/src/client/views.clj
+++ b/apps/client/src/client/views.clj
@@ -22,7 +22,7 @@
   [{:keys [avatar username permitted-member] :as user}]
   (if (and user (not (= username "guest")))
     [:header#top
-     [:h1 [:a.home {:href "/"} "sharing.io"]]
+     [:h1 [:a.home {:href "/"} "pair.sharing.io"]]
      [:nav
       (when (and permitted-member (not (= (seq (:ssh-keys user)) nil)))
         (list
@@ -31,7 +31,7 @@
       [:p [:img {:width "50px" :src avatar :alt (str "avatar icon for "username)}]
        [:a.logout {:href "/logout"} "logout"]]]]
   [:header#top
-   [:h1 [:a.home {:href "/"} "sharing.io"]
+   [:h1 [:a.home {:href "/"} "pair.sharing.io"]
     (when (= "guest" username)[:sup "public link"])]
    [:nav
     (when (nil? user) [:a {:href "/login"} "login with github"])]]))
@@ -78,7 +78,8 @@
   (layout
    [:main#splash
     [:section#cta
-     [:p.tagline "Sharing is Pairing"]
+     [:p.home-title "Pair"]
+     [:p.tagline "Pairing is sharing"]
      (if permitted-member
        ;; if has no ssh-keys
        (if (not (= (seq (:ssh-keys user)) nil))
@@ -94,14 +95,15 @@
        [:div.display-block
         [:div#more-info.display-block
          [:p
-          "Sharable Pairing Environments (on Equinix Metal)."]
+          "Sharable Kubernetes-native pairing environments running on Equinix Metal."]
          [:p
           "Contribute over at "
           [:a {:href "https://github.com/sharingio/pair"} "GitHub"]
           " and "
           [:a {:href "https://gitlab.com/sharingio/pair"} "GitLab"]
           "."]]
-        [:p "To use sharing.io, you must be a public member of a permitted github org."]
+        (when (not= (env :pair-permitted-orgs) "*")
+          [:p "To use Pair, you must be a public member of a permitted github org."])
         ]
        )]]
    user))


### PR DESCRIPTION
- update "_sharing.io_" -> "_pair.sharing.io_"
- update "_sharing is pairing_" -> "_Pair_"
- add "_pairing is sharing_"
- update the description to "_Sharable Kubernetes-native pairing environments running on Equinix Metal_"

