### PR TITLE
Add more registry mirrors

### DIFF
--- a/.sharing.io/pair-dev-registry.yaml
+++ b/.sharing.io/pair-dev-registry.yaml
@@ -121,8 +121,6 @@ kind: Ingress
 metadata:
   name: sharingio-pair-registry
   namespace: sharingio-pair
-  annotations:
-    kubernetes.io/ingress.class: $SHARINGIO_PAIR_INSTANCE_INGRESS_CLASS_NAME
 spec:
   ingressClassName: $SHARINGIO_PAIR_INSTANCE_INGRESS_CLASS_NAME
   tls:

--- a/.sharing.io/pair-dev-registry.yaml
+++ b/.sharing.io/pair-dev-registry.yaml
@@ -19,6 +19,7 @@ data:
       headers:
         X-Content-Type-Options:
         - nosniff
+        Registry-Mirrors-From: [docker]
     log:
       fields:
         service: registry

--- a/charts/sharingio-pair/templates/cert.yaml
+++ b/charts/sharingio-pair/templates/cert.yaml
@@ -19,8 +19,8 @@ spec:
     {{- end }}
     {{- if .Values.registry.enabled }}
     {{- if .Values.registry.ingress.certmanager.enabled }}
-    {{- range .Values.registry.ingress.hosts }}
-    - {{ .host | quote }}
+    {{ range .Values.registry.mirrors }}
+    - "{{ .name }}{{ $.Values.registry.ingress.domainSuffix }}"
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/sharingio-pair/templates/configmap-registry.yaml
+++ b/charts/sharingio-pair/templates/configmap-registry.yaml
@@ -1,13 +1,39 @@
 {{- if .Values.registry.enabled }}
+{{ $fullname := include "sharingio-pair.fullname" . }}
+{{ $labels := include "sharingio-pair.labels" . }}
+{{ $selectorLabels := include "sharingio-pair.selectorLabels" . }}
+{{ range $.Values.registry.mirrors }}
+{{ $registryName := .name }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "sharingio-pair.fullname" . }}-registry
+  name: {{ $fullname }}-registry-{{ .name }}
   labels:
     app: registry
     app.kubernetes.io/part-of: sharingio-pair
-    {{- include "sharingio-pair.labels" . | nindent 4 }}
+    {{- $labels | nindent 4 }}
 data:
   config.yml: |
-    {{- toYaml .Values.registry.config | nindent 4 }}
+    version: 0.1
+    log:
+      fields:
+        service: registry
+    storage:
+      cache:
+        blobdescriptor: inmemory
+      filesystem:
+        rootdirectory: /var/lib/registry
+    http:
+      addr: :5000
+      headers:
+        X-Content-Type-Options: [nosniff]
+    health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3
+    proxy:
+      remoteurl: {{ .url }}
+{{ printf "---" }}
+{{- end }}
 {{- end }}

--- a/charts/sharingio-pair/templates/configmap-registry.yaml
+++ b/charts/sharingio-pair/templates/configmap-registry.yaml
@@ -27,6 +27,7 @@ data:
       addr: :5000
       headers:
         X-Content-Type-Options: [nosniff]
+        Registry-Mirrors-From: {{ .name }}
     health:
       storagedriver:
         enabled: true

--- a/charts/sharingio-pair/templates/deployment-cluster-api-manager.yaml
+++ b/charts/sharingio-pair/templates/deployment-cluster-api-manager.yaml
@@ -72,13 +72,13 @@ spec:
             {{- if .Values.instance.nodeSize }}
             - name: APP_INSTANCE_NODE_SIZE
               value: {{ .Values.instance.nodeSize }}
+            {{- end }}
             - name: APP_ADMIN_EMAIL_DOMAIN
               value: "{{ .Values.adminEmailDomain }}"
             - name: APP_NON_ADMIN_INSTANCE_MAX_AMOUNT
               value: "{{ .Values.maxInstancesForNonAdmins }}"
             - name: APP_INSTANCE_CONTAINER_REGISTRY_MIRRORS
-              value: "{{ range .Values.registry.ingress.hosts }}https://{{ .host }} {{ end }}{{ range .Values.instance.extraRegistryMirrors }}https://{{ . }} {{ end }}"
-            {{- end }}
+              value: "{{ range .Values.registry.mirrors }}https://{{ .name }}{{ $.Values.registry.ingress.domainSuffix }} {{ end }}{{ range .Values.instance.extraRegistryMirrors }}https://{{ . }} {{ end }}"
             {{- if .Values.clusterapimanager.extraEnv }}
             {{- toYaml .Values.clusterapimanager.extraEnv | nindent 12 }}
             {{- end }}

--- a/charts/sharingio-pair/templates/deployment-registry.yaml
+++ b/charts/sharingio-pair/templates/deployment-registry.yaml
@@ -1,90 +1,98 @@
 {{- if .Values.registry.enabled }}
+{{ $fullname := include "sharingio-pair.fullname" . }}
+{{ $labels := include "sharingio-pair.labels" . }}
+{{ $selectorLabels := include "sharingio-pair.selectorLabels" . }}
+{{ range $.Values.registry.mirrors }}
+{{ $registryName := .name }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "sharingio-pair.fullname" . }}-registry
+  name: {{ $fullname }}-registry-{{ $registryName }}
   labels:
     app: registry
     app.kubernetes.io/part-of: sharingio-pair
-    {{- include "sharingio-pair.labels" . | nindent 4 }}
-  annotations:
-    checksum/configmap-registry: {{ include (print $.Template.BasePath "/configmap-registry.yaml") . | sha256sum }}
+    mirroring: {{ .url }}
+    {{- $labels | nindent 4 }}
 spec:
-{{- if not .Values.registry.autoscaling.enabled }}
-  replicas: {{ .Values.registry.replicaCount }}
+{{- if not $.Values.registry.autoscaling.enabled }}
+  replicas: {{ $.Values.registry.replicaCount }}
 {{- end }}
   selector:
     matchLabels:
       app: registry
+      mirroring: {{ .url }}
       app.kubernetes.io/part-of: sharingio-pair
-      {{- include "sharingio-pair.selectorLabels" . | nindent 6 }}
+      {{- $selectorLabels | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.registry.podAnnotations }}
+    {{- with $.Values.registry.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
         app: registry
+        mirroring: {{ .url }}
         app.kubernetes.io/part-of: sharingio-pair
-        {{- include "sharingio-pair.selectorLabels" . | nindent 8 }}
+        {{- $selectorLabels | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.registry.podSecurityContext | nindent 8 }}
+        {{- toYaml $.Values.registry.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}-registry
+        - name: {{ $.Chart.Name }}-registry
           securityContext:
-            {{- toYaml .Values.registry.securityContext | nindent 12 }}
-          image: "{{ .Values.registry.image.repository }}:{{ .Values.registry.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.registry.image.pullPolicy }}
+            {{- toYaml $.Values.registry.securityContext | nindent 12 }}
+          image: "{{ $.Values.registry.image.repository }}:{{ $.Values.registry.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $.Values.registry.image.pullPolicy }}
           env:
             - name: TZ
-              value: {{ .Values.timezone }}
-            {{- if .Values.registry.extraEnv }}
-            {{- toYaml .Values.registry.extraEnv | nindent 12 }}
+              value: {{ $.Values.timezone }}
+            {{- if $.Values.registry.extraEnv }}
+            {{- toYaml $.Values.registry.extraEnv | nindent 12 }}
             {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.registry.service.port }}
+              containerPort: {{ $.Values.registry.service.port }}
               protocol: TCP
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.registry.service.port }}
+              port: {{ $.Values.registry.service.port }}
             initialDelaySeconds: 2
             periodSeconds: 10
           livenessProbe:
             tcpSocket:
-              port: {{ .Values.registry.service.port }}
+              port: {{ $.Values.registry.service.port }}
             initialDelaySeconds: 1
             periodSeconds: 20
           volumeMounts:
-          - name: distribution-config
+          - name: distribution-config-{{ $registryName }}
             mountPath: /etc/docker/registry/config.yml
             subPath: config.yml
           - name: var-lib-registry
             mountPath: /var/lib/registry
           resources:
-            {{- toYaml .Values.registry.resources | nindent 12 }}
-      {{- with .Values.registry.nodeSelector }}
+            {{- toYaml $.Values.registry.resources | nindent 12 }}
+      {{- with $.Values.registry.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.registry.affinity }}
+      {{- with $.Values.registry.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.registry.tolerations }}
+      {{- with $.Values.registry.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
         - name: distribution-config
           configMap:
-            name: {{ include "sharingio-pair.fullname" . }}-registry
+            name: {{ $fullname }}-registry-{{ $registryName }}
         - name: var-lib-registry
           emptyDir: {}
+{{ printf "---" }}
+{{- end }}
 {{- end }}

--- a/charts/sharingio-pair/templates/deployment-registry.yaml
+++ b/charts/sharingio-pair/templates/deployment-registry.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: registry
     app.kubernetes.io/part-of: sharingio-pair
-    mirroring: {{ .url }}
+    mirroring: {{ .name }}
     {{- $labels | nindent 4 }}
 spec:
 {{- if not $.Values.registry.autoscaling.enabled }}
@@ -20,7 +20,7 @@ spec:
   selector:
     matchLabels:
       app: registry
-      mirroring: {{ .url }}
+      mirroring: {{ .name }}
       app.kubernetes.io/part-of: sharingio-pair
       {{- $selectorLabels | nindent 6 }}
   template:
@@ -31,7 +31,7 @@ spec:
     {{- end }}
       labels:
         app: registry
-        mirroring: {{ .url }}
+        mirroring: {{ .name }}
         app.kubernetes.io/part-of: sharingio-pair
         {{- $selectorLabels | nindent 8 }}
     spec:
@@ -68,7 +68,7 @@ spec:
             initialDelaySeconds: 1
             periodSeconds: 20
           volumeMounts:
-          - name: distribution-config-{{ $registryName }}
+          - name: distribution-config
             mountPath: /etc/docker/registry/config.yml
             subPath: config.yml
           - name: var-lib-registry

--- a/charts/sharingio-pair/templates/ingress-registry.yaml
+++ b/charts/sharingio-pair/templates/ingress-registry.yaml
@@ -19,6 +19,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ $.Values.ingress.className }}
   {{- if $.Values.registry.ingress.certmanager }}
   tls:
     - hosts:

--- a/charts/sharingio-pair/templates/ingress-registry.yaml
+++ b/charts/sharingio-pair/templates/ingress-registry.yaml
@@ -1,30 +1,34 @@
 {{- if .Values.registry.enabled -}}
-{{- $fullName := include "sharingio-pair.fullname" . -}}
 {{- $svcPort := .Values.registry.service.port -}}
+{{ $fullname := include "sharingio-pair.fullname" . }}
+{{ $labels := include "sharingio-pair.labels" . }}
+{{ $selectorLabels := include "sharingio-pair.selectorLabels" . }}
+{{ range $.Values.registry.mirrors }}
+{{ $registryName := .name }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}-registry
+  name: {{ $fullname }}-registry-{{ $registryName }}
   labels:
-    {{- include "sharingio-pair.labels" . | nindent 4 }}
-  {{- with .Values.registry.ingress.annotations }}
+    {{- $labels | nindent 4 }}
+  {{- with $.Values.registry.ingress.annotations }}
   annotations:
     {{- if $.Values.registry.ingress.certmanager.enabled }}
-    cert-manager.io/cluster-issuer: {{ include "sharingio-pair.fullname" . }}-letsencrypt
+    cert-manager.io/cluster-issuer: {{ $fullname }}-letsencrypt
     {{- end }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.registry.ingress.certmanager }}
+  {{- if $.Values.registry.ingress.certmanager }}
   tls:
     - hosts:
-    {{- range .Values.registry.ingress.hosts }}
+    {{- range $.Values.registry.ingress.hosts }}
         - {{ .host | quote }}
     {{- end }}
-      secretName: {{ include "sharingio-pair.fullname" . }}-letsencrypt
-  {{- else if .Values.registry.ingress.tls }}
+      secretName: {{ $fullname }}-letsencrypt
+  {{- else if $.Values.registry.ingress.tls }}
   tls:
-    {{- range .Values.registry.ingress.tls }}
+    {{- range $.Values.registry.ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -33,18 +37,16 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.registry.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: "{{ .name }}{{ $.Values.registry.ingress.domainSuffix }}"
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ . }}
+          - path: /
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ $fullName }}-registry
+                name: {{ $fullname }}-registry-{{ $registryName }}
                 port:
                   number: {{ $svcPort }}
-          {{- end }}
-    {{- end }}
+{{ printf "---" }}
   {{- end }}
+{{- end }}

--- a/charts/sharingio-pair/templates/ingress.yaml
+++ b/charts/sharingio-pair/templates/ingress.yaml
@@ -15,6 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ $.Values.ingress.className }}
   {{- if .Values.ingress.certmanager }}
   tls:
     - hosts:

--- a/charts/sharingio-pair/templates/service-registry.yaml
+++ b/charts/sharingio-pair/templates/service-registry.yaml
@@ -1,21 +1,29 @@
 {{- if .Values.registry.enabled }}
+{{ $fullname := include "sharingio-pair.fullname" . }}
+{{ $labels := include "sharingio-pair.labels" . }}
+{{ $selectorLabels := include "sharingio-pair.selectorLabels" . }}
+{{ range $.Values.registry.mirrors }}
+{{ $registryName := .name }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "sharingio-pair.fullname" . }}-registry
+  name: {{ $fullname }}-registry-{{ .name }}
   labels:
     app: registry
     app.kubernetes.io/part-of: sharingio-pair
-    {{- include "sharingio-pair.labels" . | nindent 4 }}
+    {{- $labels | nindent 4 }}
 spec:
-  type: {{ .Values.registry.service.type }}
+  type: {{ $.Values.registry.service.type }}
   ports:
-    - port: {{ .Values.registry.service.port }}
-      targetPort: {{ .Values.registry.service.port }}
+    - port: {{ $.Values.registry.service.port }}
+      targetPort: {{ $.Values.registry.service.port }}
       protocol: TCP
       name: http
   selector:
     app: registry
+    mirroring: {{ .url }}
     app.kubernetes.io/part-of: sharingio-pair
-    {{- include "sharingio-pair.selectorLabels" . | nindent 4 }}
+    {{- $selectorLabels | nindent 4 }}
+{{ printf "---" }}
+{{- end}}
 {{- end}}

--- a/charts/sharingio-pair/templates/service-registry.yaml
+++ b/charts/sharingio-pair/templates/service-registry.yaml
@@ -21,7 +21,7 @@ spec:
       name: http
   selector:
     app: registry
-    mirroring: {{ .url }}
+    mirroring: {{ .name }}
     app.kubernetes.io/part-of: sharingio-pair
     {{- $selectorLabels | nindent 4 }}
 {{ printf "---" }}

--- a/charts/sharingio-pair/values.yaml
+++ b/charts/sharingio-pair/values.yaml
@@ -253,27 +253,19 @@ reconciler:
 registry:
   enabled: false
 
-  config:
-    version: 0.1
-    log:
-      fields:
-        service: registry
-    storage:
-      cache:
-        blobdescriptor: inmemory
-      filesystem:
-        rootdirectory: /var/lib/registry
-    http:
-      addr: :5000
-      headers:
-        X-Content-Type-Options: [nosniff]
-    health:
-      storagedriver:
-        enabled: true
-        interval: 10s
-        threshold: 3
-    proxy:
-      remoteurl: https://registry-1.docker.io
+  mirrors:
+    - name: docker
+      url: https://registry-1.docker.io
+    - name: gitlab
+      url: https://registry.gitlab.com
+    - name: quay
+      url: https://quay.io
+    - name: k8s
+      url: https://registry.k8s.io
+    - name: gcr
+      url: https://gcr.io
+    - name: k8sgcr
+      url: https://k8s.gcr.io
 
   replicaCount: 1
 
@@ -317,9 +309,7 @@ registry:
     annotations: {}
     #   kubernetes.io/ingress.class: nginx
     #   kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: registry.chart-example.local
-        paths: []
+    domainSuffix: -registry.chart-example.local
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:

--- a/charts/sharingio-pair/values.yaml
+++ b/charts/sharingio-pair/values.yaml
@@ -39,6 +39,7 @@ imagePullSecrets: []
 
 ingress:
   enabled: false
+  ingress: ""
   certmanager:
     enabled: false
   annotations:
@@ -304,6 +305,7 @@ registry:
 
   ingress:
     enabled: false
+    className: ""
     certmanager:
       enabled: false
     annotations: {}

--- a/manifests/pair.yaml
+++ b/manifests/pair.yaml
@@ -88,7 +88,4 @@ spec:
         enabled: true
         certmanager:
           enabled: true
-        hosts:
-          - host: docker-mirror.sharing.io
-            paths:
-              - /
+          domainSuffix: -docker-mirror.sharing.io

--- a/manifests/pair.yaml
+++ b/manifests/pair.yaml
@@ -76,6 +76,7 @@ spec:
         tag: ${SHARINGIO_PAIR_TAG}
     ingress:
       enabled: true
+      className: nginx
       certmanager:
         enabled: true
       hosts:
@@ -86,6 +87,7 @@ spec:
       enabled: true
       ingress:
         enabled: true
+        className: nginx
         certmanager:
           enabled: true
-          domainSuffix: -docker-mirror.sharing.io
+        domainSuffix: -docker-mirror.bobymcbobs.pair.sharing.io

--- a/manifests/pair.yaml
+++ b/manifests/pair.yaml
@@ -85,6 +85,23 @@ spec:
             - /
     registry:
       enabled: true
+
+      mirrors:
+        - name: docker
+          url: https://registry-1.docker.io
+        - name: gitlab
+          url: https://registry.gitlab.com
+        - name: quay
+          url: https://quay.io
+        - name: k8s
+          url: https://registry.k8s.io
+        - name: gcr
+          url: https://gcr.io
+        - name: k8sgcr
+          url: https://k8s.gcr.io
+        - name: ghcr
+          url: https://ghcr.io
+
       ingress:
         enabled: true
         className: nginx


### PR DESCRIPTION
In the Helm chart, add more registry proxy caches for different registries which are used through images on instances